### PR TITLE
Improve cad-design page mobile layout

### DIFF
--- a/app/App.css
+++ b/app/App.css
@@ -235,11 +235,16 @@ body:has(.App) {
   scroll-timeline-name: --heroTimeline;
 }
 
-.social-links {
-  animation: colorShift;
-  animation-timeline: --heroTimeline;
-  animation-range: cover 0% cover 10%;
-  animation-fill-mode: forwards;
+/* The scroll-driven fill shift only makes sense for the desktop bottom-left
+   placement. On mobile the icons live in a solid pill (top-right) and keep a
+   fixed high-contrast fill instead. */
+@media (min-width: 768px) {
+  .social-links {
+    animation: colorShift;
+    animation-timeline: --heroTimeline;
+    animation-range: cover 0% cover 10%;
+    animation-fill-mode: forwards;
+  }
 }
 
 #output pre,

--- a/app/cad-design/page.tsx
+++ b/app/cad-design/page.tsx
@@ -48,31 +48,39 @@ const Page = () => {
   ];
 
   return (
-    <div className="flex flex-row flex-wrap justify-evenly w-full h-full py-24 gap-4">
+    <div className="w-full min-h-screen py-16 sm:py-24 px-4 sm:px-6">
       <section
         id="scroll-section"
-        className="relative flex flex-col w-screen items-center"
+        className="relative mx-auto flex w-full max-w-screen-xl flex-col"
       >
-        <div className="max-w-screen-xl w-full text-left md:[&>*:nth-child(even)]:flex-row-reverse [&>*:nth-child(even)]:text-right flex flex-col gap-y-14">
-          <a className="text-color3 flex items-center" href="./">
-            <i className="bi bi-arrow-left-square text-5xl"></i>
-            <h1 className="text-xl ml-4 font-[400]">Home</h1>
-          </a>
+        <a
+          className="group mb-10 flex w-fit items-center text-color3 sm:mb-14"
+          href="./"
+        >
+          <i className="bi bi-arrow-left-square text-4xl transition-transform group-hover:-translate-x-1 sm:text-5xl"></i>
+          <h1 className="ml-3 text-lg font-[400] sm:ml-4 sm:text-xl">Home</h1>
+        </a>
+
+        <div className="flex flex-col gap-8 text-center sm:gap-14 md:[&>*:nth-child(even)]:flex-row-reverse md:[&>*:nth-child(even)]:text-right">
           {modelArray.map((modelObject) => {
             const { src, title, description } = modelObject;
             return (
               <div
                 key={src}
-                className="flex w-full items-center project-card overflow-hidden bg-color3 text-white"
+                className="project-card group flex w-full flex-col items-center overflow-hidden rounded-2xl bg-color3 text-white shadow-lg shadow-color3/20 transition-shadow hover:shadow-xl md:flex-row md:text-left"
               >
-                <TinyViewport modelSrc={src} />
-                <div className="relative h-full">
-                  <div className="px-6 py-8">
-                    <h1 className="text-3xl font-bold mb-4 group-hover:tracking-widest transition-all">
-                      {title}
-                    </h1>
-                    <p>{description}</p>
-                  </div>
+                <div className="flex w-full shrink-0 justify-center md:w-80">
+                  <TinyViewport modelSrc={src} />
+                </div>
+                <div className="w-full px-6 py-8 sm:px-8">
+                  <h2 className="mb-3 text-2xl font-bold transition-all group-hover:tracking-widest sm:mb-4 sm:text-3xl">
+                    {title}
+                  </h2>
+                  {description && (
+                    <p className="text-sm leading-relaxed text-white/80 sm:text-base">
+                      {description}
+                    </p>
+                  )}
                 </div>
               </div>
             );

--- a/app/cad-design/page.tsx
+++ b/app/cad-design/page.tsx
@@ -29,7 +29,7 @@ const Page = () => {
         "A custom mount for a GoPro Hero 8 that allows for easy mounting and removal from a FPV drone. Printed in TPU for durability and vibration dampening.",
     },
     {
-      src: "base_3.stl",
+      src: "base_3.STL",
       title: "LED Lamp internals",
       description:
         "Custom designed support for a WS2812b powered lamp. Designed priorities were cooling and printing efficiency.",
@@ -67,12 +67,12 @@ const Page = () => {
             return (
               <div
                 key={src}
-                className="project-card group flex w-full flex-col items-center overflow-hidden rounded-2xl bg-color3 text-white shadow-lg shadow-color3/20 transition-shadow hover:shadow-xl md:flex-row md:text-left"
+                className="project-card group flex w-full flex-col items-center gap-4 overflow-hidden rounded-2xl bg-color3 p-4 text-white shadow-lg shadow-color3/20 transition-shadow hover:shadow-xl sm:gap-6 sm:p-6 md:flex-row md:text-left"
               >
-                <div className="flex w-full shrink-0 justify-center md:w-80">
+                <div className="w-full max-w-xs shrink-0 overflow-hidden rounded-xl md:w-80 md:max-w-none">
                   <TinyViewport modelSrc={src} />
                 </div>
-                <div className="w-full px-6 py-8 sm:px-8">
+                <div className="w-full px-2 sm:px-4">
                   <h2 className="mb-3 text-2xl font-bold transition-all group-hover:tracking-widest sm:mb-4 sm:text-3xl">
                     {title}
                   </h2>

--- a/components/Landing/Landing.tsx
+++ b/components/Landing/Landing.tsx
@@ -37,15 +37,27 @@ function Landing({ blogCallout }: LandingProps): React.ReactNode {
       onMouseEnter={() => setGradientVisible(true)}
       onMouseLeave={() => setGradientVisible(false)}
     >
-      <div className="social-links absolute flex space-x-8 bottom-6 z-10 max-w-screen-xl md:px-12 left-8 md:left-12 md:bottom-12 lg:left-24 mx-auto">
+      <div
+        className="social-links fixed right-3 top-3 z-50 flex items-center gap-4 rounded-full bg-color3 px-4 py-2.5 shadow-lg ring-1 ring-black/10 fill-light1
+                   md:absolute md:right-auto md:top-auto md:bottom-12 md:left-12 md:z-10 md:mx-auto md:max-w-screen-xl md:gap-8 md:rounded-none md:bg-transparent md:px-12 md:py-0 md:shadow-none md:ring-0
+                   lg:left-24"
+      >
         <a
-          className=""
+          aria-label="Lucas Stella on LinkedIn"
+          className="flex items-center justify-center rounded-full transition-transform hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-light1 focus-visible:ring-offset-2 focus-visible:ring-offset-color3 md:focus-visible:ring-offset-transparent"
           target="_blank"
+          rel="noopener noreferrer"
           href="https://www.linkedin.com/in/lucas-stella-28700615a/"
         >
           <LinkedInIcon dim={36} />
         </a>
-        <a className="" target="_blank" href="https://github.com/thestellarl">
+        <a
+          aria-label="Lucas Stella on GitHub"
+          className="flex items-center justify-center rounded-full transition-transform hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-light1 focus-visible:ring-offset-2 focus-visible:ring-offset-color3 md:focus-visible:ring-offset-transparent"
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://github.com/thestellarl"
+        >
           <GithubIcon dim={36} />
         </a>
       </div>

--- a/components/TinyViewport/index.tsx
+++ b/components/TinyViewport/index.tsx
@@ -20,11 +20,25 @@ const TinyViewport = ({
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+    const container = ref.current;
+    if (container === null) return;
 
-    const renderer = new THREE.WebGLRenderer();
-    renderer.setSize(width, height);
+    // Size the renderer to the actual rendered container so the viewport can
+    // shrink responsively on mobile. Fall back to the props before layout.
+    let viewWidth = container.clientWidth || width;
+    let viewHeight = container.clientHeight || height;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(
+      75,
+      viewWidth / viewHeight,
+      0.1,
+      1000
+    );
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(viewWidth, viewHeight);
     renderer.shadowMap.enabled = true;
     scene.background = new THREE.Color("#CFDBD5");
     scene.fog = new THREE.Fog("#CFDBD5", 10, 50);
@@ -52,10 +66,9 @@ const TinyViewport = ({
     mesh.receiveShadow = true;
     scene.add(mesh);
 
-    if (ref.current !== null) {
-      ref.current.appendChild(renderer.domElement);
-    }
-    const controls = new OrbitControls(camera, ref.current as HTMLElement);
+    container.appendChild(renderer.domElement);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
     controls.autoRotate = true;
     controls.autoRotateSpeed = 1;
     controls.enableDamping = true;
@@ -101,25 +114,54 @@ const TinyViewport = ({
 
     camera.position.set(0, 400, 30);
     camera.lookAt(new THREE.Vector3(0, 0, 0));
+
+    // Keep the camera and renderer in sync with the container size so the
+    // model stays centred and undistorted as the layout reflows.
+    const resizeObserver = new ResizeObserver(() => {
+      viewWidth = container.clientWidth;
+      viewHeight = container.clientHeight;
+      if (viewWidth === 0 || viewHeight === 0) return;
+      camera.aspect = viewWidth / viewHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(viewWidth, viewHeight);
+    });
+    resizeObserver.observe(container);
+
+    let frameId = 0;
     function animate() {
-      requestAnimationFrame(animate);
+      frameId = requestAnimationFrame(animate);
       renderer.render(scene, camera);
       controls.update();
     }
     animate();
+
     return () => {
-      ref.current?.removeChild(renderer.domElement);
+      cancelAnimationFrame(frameId);
+      resizeObserver.disconnect();
+      controls.dispose();
+      renderer.dispose();
+      if (renderer.domElement.parentNode === container) {
+        container.removeChild(renderer.domElement);
+      }
     };
-  }, [ref]);
+  }, [modelSrc, width, height]);
+
   return <Wrapper ref={ref} $height={height} $width={width} />;
 };
 
 const Wrapper = styled.div<{ $width: number; $height: number }>`
-  width: ${({ $width }) => $width}px;
-  height: ${({ $height }) => $height}px;
-  background: lightblue;
+  width: 100%;
+  max-width: ${({ $width }) => $width}px;
+  aspect-ratio: ${({ $width, $height }) => `${$width} / ${$height}`};
+  background: #cfdbd5;
   overflow: hidden;
   transition: transform 0.2s ease-in-out;
+
+  & canvas {
+    display: block;
+    width: 100% !important;
+    height: 100% !important;
+  }
 `;
 
 export default TinyViewport;


### PR DESCRIPTION
- Stack 3D viewport above text on mobile (flex-col), switch to side-by-side
  on md+; alternating reverse/right-align now scoped to desktop only so
  mobile text reads centered instead of awkwardly right-aligned
- Replace w-screen with w-full + horizontal padding to avoid mobile overflow
- Add rounded corners, shadow, and refined spacing/typography to project cards
- Make TinyViewport responsive: renderer/camera now track container size via
  ResizeObserver so the model scales down on narrow screens instead of
  overflowing; canvas fills a fluid square wrapper (max-width preserves the
  600px Landing usage)
- Drop the pre-render lightblue flash in favor of the scene background color